### PR TITLE
Add KnnQuery DSL support for dense vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ from elasticquerydsl.filter import (
     MultiMatchQuery,
     RangeQuery,
     GeoDistanceQuery,
+    KnnQuery,
     QueryStringQuery
 )
 
@@ -134,6 +135,31 @@ geo_query = GeoDistanceQuery(
 )
 print("Geo Distance Query:")
 print(geo_query.to_query())
+```
+
+### Dense Vector (KNN) Queries
+
+```python
+# kNN query for dense_vector retrieval
+knn_query = KnnQuery(
+    field="embedding",
+    query_vector=[0.12, -0.07, 0.34, 0.91],
+    k=10,
+    num_candidates=100
+)
+print("KNN Query:")
+print(knn_query.to_query())
+
+# Hybrid kNN query with an additional filter
+hybrid_knn_query = KnnQuery(
+    field="embedding",
+    query_vector=[0.12, -0.07, 0.34, 0.91],
+    k=10,
+    num_candidates=100,
+    filter=MatchQuery(field="status", value="active")
+)
+print("Hybrid KNN Query:")
+print(hybrid_knn_query.to_query())
 ```
 
 ### Query String and Complex Queries

--- a/elasticquerydsl/__init__.py
+++ b/elasticquerydsl/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Nikhil Kumar"""
 __email__ = "nikhil.kumar@workindia.in"
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/elasticquerydsl/filter.py
+++ b/elasticquerydsl/filter.py
@@ -751,6 +751,63 @@ class GeoDistanceQuery(FilterDSL):
         return {"geo_distance": geo_distance_subquery}
 
 
+class KnnQuery(FilterDSL):
+    def __init__(
+        self,
+        field: str,
+        query_vector: t.List[float],
+        k: int,
+        num_candidates: int,
+        filter: t.Optional[DSLQuery] = None,
+        boost: t.Optional[float] = None,
+        _name: t.Optional[str] = None,
+    ):
+        """
+        Initializes a KnnQuery object.
+
+        Use Cases:
+        - Retrieve nearest neighbors for dense_vector fields using approximate kNN.
+        - Combine vector retrieval with additional filters for hybrid search.
+
+        Args:
+            field (str): The dense_vector field name.
+            query_vector (List[float]): The vector used to find nearest neighbors.
+            k (int): Number of nearest neighbors to return.
+            num_candidates (int): Number of candidates to consider during ANN search.
+            filter (DSLQuery, optional): Query filter applied during kNN retrieval.
+            boost (float, optional): Boost value to influence the relevance score. [default: 1.0]
+            _name (str, optional): The name for the query. [default: None]
+        """
+        super().__init__(boost, _name)
+        self.field = field
+        self.query_vector = query_vector
+        self.k = k
+        self.num_candidates = num_candidates
+        self.filter = filter
+        self.boost = boost
+        self.knn_query = self._make_query()
+
+    def to_query(self):
+        return self.knn_query
+
+    def _make_query(self):
+        knn_subquery = {
+            "field": self.field,
+            "query_vector": self.query_vector,
+            "k": self.k,
+            "num_candidates": self.num_candidates,
+        }
+
+        if self.filter is not None:
+            knn_subquery["filter"] = self.filter.to_query()
+        if self.boost is not None:
+            knn_subquery["boost"] = self.boost
+        if self.name:
+            knn_subquery["_name"] = self.name
+
+        return {"knn": knn_subquery}
+
+
 class QueryStringQuery(FilterDSL):
     def __init__(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 parse = ^

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ develop_requires = install_requires + [
 
 setup(
     name="elasticquery-dsl-py",
-    version="1.0.0",
+    version="1.1.0",
     url="https://github.com/workindia/elasticquery-dsl-py",
     license="MIT license",
     author="Nikhil Kumar",

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -13,6 +13,7 @@ from elasticquerydsl.filter import (
     ScriptQuery,
     RangeQuery,
     GeoDistanceQuery,
+    KnnQuery,
     QueryStringQuery,
 )
 
@@ -306,6 +307,46 @@ class TestFilterDSL(unittest.TestCase):
                 "validation_method": "IGNORE_MALFORMED",
                 "boost": 1.5,
                 "_name": "geo_distance_test",
+            }
+        }
+        self.assertEqual(query.to_query(), expected)
+
+    def test_knn_query(self):
+        query = KnnQuery(
+            field="embedding",
+            query_vector=[0.1, 0.2, 0.3],
+            k=10,
+            num_candidates=100,
+        )
+        expected = {
+            "knn": {
+                "field": "embedding",
+                "query_vector": [0.1, 0.2, 0.3],
+                "k": 10,
+                "num_candidates": 100,
+            }
+        }
+        self.assertEqual(query.to_query(), expected)
+
+        dsl_filter = TermQuery(field="status", value="active")
+        query = KnnQuery(
+            field="embedding",
+            query_vector=[0.1, 0.2, 0.3],
+            k=10,
+            num_candidates=100,
+            filter=dsl_filter,
+            boost=1.2,
+            _name="knn_test",
+        )
+        expected = {
+            "knn": {
+                "field": "embedding",
+                "query_vector": [0.1, 0.2, 0.3],
+                "k": 10,
+                "num_candidates": 100,
+                "filter": {"term": {"status": {"value": "active"}}},
+                "boost": 1.2,
+                "_name": "knn_test",
             }
         }
         self.assertEqual(query.to_query(), expected)


### PR DESCRIPTION
## Summary

This PR adds native kNN query support to `elasticquery-dsl-py` by introducing a new `KnnQuery` filter DSL class for Elasticsearch dense vector retrieval.

### What’s included

- Added `KnnQuery` in `elasticquerydsl/filter.py`
  - Required fields: `field`, `query_vector`, `k`, `num_candidates`
  - Optional fields: `filter`, `boost`, `_name`
  - Emits valid Elasticsearch `knn` query structure
- Added unit tests in `tests/test_filter.py`
  - Basic kNN query generation
  - kNN query with DSL filter + boost + name
- Updated `README.md`
  - Added `KnnQuery` import in examples
  - Added a new section with dense vector kNN and hybrid kNN usage examples

## Why

Vector similarity search is a common Elasticsearch use case. This change makes kNN queries first-class in the DSL and keeps query construction consistent with other filter/query helpers in the library.

## Test Plan

- [x] `python -m unittest tests.test_filter`
- [x] Validate generated query dictionaries for:
  - [x] basic kNN query
  - [x] kNN query with filter/boost/name